### PR TITLE
Update URL to use new Longtail example image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This repository contains all the Longtail instant answers. If you are developing
 
 ### Longtail Instant Answer Example
 
-![lyrics example](https://s3.amazonaws.com/ddg-assets/docs/longtail_example.png)
+![Lyrics Search Example](https://raw.githubusercontent.com/duckduckgo/duckduckgo-documentation/master/duckduckhack/assets/longtail_readme_example.png)


### PR DESCRIPTION
New image added to Docs in https://github.com/duckduckgo/duckduckgo-documentation/pull/173

That PR needs to be merged before this.

//cc @jdorweiler 
