### PR TITLE
Add new Instant Answer for CVE information

### DIFF
--- a/lib/DDG/Longtail/CveSummary.pm
+++ b/lib/DDG/Longtail/CveSummary.pm
@@ -10,6 +10,6 @@ topics 'security';
 category 'q/a';
 primary_example_queries 'CVE-1999-0002';
 #secondary_example_queries 'panama lyrics', 'lean on me lyrics';
-code_url 'https://github.com/duckduckgo/zeroclickinfo-longtail/blob/master/lib/DDG/Longtail/Lyrics/';
+code_url 'https://github.com/MoriTanosuke/zeroclickinfo-longtail/blob/master/lib/DDG/Longtail/CveSummary.pm';
 
 1;

--- a/lib/DDG/Longtail/CveSummary.pm
+++ b/lib/DDG/Longtail/CveSummary.pm
@@ -1,0 +1,15 @@
+package DDG::Longtail::Lyrics;
+
+use DDG::Longtail;
+
+name 'CVE Summary';
+description 'Displays a short summary of a Common Vulnerabilities and Exposures (CVE).';
+source "https://cve.mitre.org";
+icon_url "/i/cve.mitre.org.ico";
+topics 'security';
+category 'q/a';
+primary_example_queries 'CVE-1999-0002';
+#secondary_example_queries 'panama lyrics', 'lean on me lyrics';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-longtail/blob/master/lib/DDG/Longtail/Lyrics/';
+
+1;

--- a/share/longtail/cve_summary/builddb.sh
+++ b/share/longtail/cve_summary/builddb.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+from xml.etree import ElementTree as ET
+
+tree = ET.parse('allitems.xml')
+root = tree.getroot()
+
+print "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+print "<add allowDups=\"false\">"
+for item in root:
+	print "<doc>"
+	name = item.get('name')
+	desc = ""
+	for child in item.findall('{http://cve.mitre.org/cve/downloads}desc'):
+		desc += child.text + " "
+	print "<field name=\"title\">" + name + "</field>"
+	print "<field name=\"paragraph\"><![CDATA[" + desc.encode('utf-8') + "]]</field>"
+	print "<field name=\"source\">https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + name + "</field>"
+	print "</doc>"
+

--- a/share/longtail/cve_summary/builddb.sh
+++ b/share/longtail/cve_summary/builddb.sh
@@ -4,16 +4,17 @@ from xml.etree import ElementTree as ET
 tree = ET.parse('allitems.xml')
 root = tree.getroot()
 
-print "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-print "<add allowDups=\"false\">"
-for item in root:
-	print "<doc>"
-	name = item.get('name')
-	desc = ""
-	for child in item.findall('{http://cve.mitre.org/cve/downloads}desc'):
-		desc += child.text + " "
-	print "<field name=\"title\">" + name + "</field>"
-	print "<field name=\"paragraph\"><![CDATA[" + desc.encode('utf-8') + "]]</field>"
-	print "<field name=\"source\">https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + name + "</field>"
-	print "</doc>"
-
+with open("data.xml", "w") as f:
+	f.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+	f.write("<add allowDups=\"false\">\n")
+	for item in root:
+		f.write("<doc>\n")
+		name = item.get('name')
+		desc = ""
+		for child in item.findall('{http://cve.mitre.org/cve/downloads}desc'):
+			desc += child.text + " "
+		f.write("\t<field name=\"title\">" + name + "</field>\n")
+		f.write("\t<field name=\"paragraph\"><![CDATA[" + desc.encode('utf-8') + "]]</field>\n")
+		f.write("\t<field name=\"source\">https://cve.mitre.org/cgi-bin/cvename.cgi?name=" + name + "</field>\n")
+		f.write("</doc>\n")
+	f.close()

--- a/share/longtail/cve_summary/download.sh
+++ b/share/longtail/cve_summary/download.sh
@@ -1,0 +1,6 @@
+#/bin/sh                                                                                                                                                                                                  
+URL=https://cve.mitre.org/data/downloads/allitems.xml.gz                                                                                                                                                  
+SOURCE_FILE=allitems.xml                                                                                                                                                                                  
+                                                                                                                                                                                                          
+curl $URL | gzip -d > $SOURCE_FILE                                                                                                                                                                        
+#TODO parse XML and extract summary   

--- a/share/longtail/cve_summary/download.sh
+++ b/share/longtail/cve_summary/download.sh
@@ -1,6 +1,5 @@
-#/bin/sh                                                                                                                                                                                                  
-URL=https://cve.mitre.org/data/downloads/allitems.xml.gz                                                                                                                                                  
-SOURCE_FILE=allitems.xml                                                                                                                                                                                  
-                                                                                                                                                                                                          
-curl $URL | gzip -d > $SOURCE_FILE                                                                                                                                                                        
-#TODO parse XML and extract summary   
+#/bin/sh
+URL=https://cve.mitre.org/data/downloads/allitems.xml.gz
+SOURCE_FILE=allitems.xml
+curl $URL | gzip -d > $SOURCE_FILE
+# now run builddb.sh


### PR DESCRIPTION
Today I wanted to get a quick summary of a CVE and I just pasted *CVE-2016-0815* into DDG - I guess I am so use to seeing IAs that I was really surprised that no information showed up. :smile: 

This PR creates the new IA (I also created https://duck.co/ia/view/cve_summary) to display the description from mitre.org. I also set the source URL to the details page of the searched CVE (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0815).

This is my first longtail IA, so I am very thankful for feedback and tips to improve it.

I splitted my code into a shell script to download the original data from mitre.org and a python script to parse XML out of the downloaded file. Is this an issue? Can I simplify it or is there a better way to do it?

---
IA Page: https://duck.co/ia/view/cve_summary