### PR TITLE
Add linked posts and parent_id vote count

### DIFF
--- a/lib/longtail/stackoverflow/README
+++ b/lib/longtail/stackoverflow/README
@@ -12,7 +12,7 @@ cp -p /usr/local/ddg/sources/stackoverflow/extract.sh .
 ./extract.sh
 rm *.7z*
 rm -rf meta*
-find . | egrep -e 'Badges|PostHistory|Comments|PostLinks' | xargs rm -rf
+find . | egrep -e 'Badges|PostHistory|Comments' | xargs rm -rf
 mkdir stackoverflow.com
 mv stackoverflow.com-Users/Users.xml stackoverflow.com/Users.xml
 mv stackoverflow.com-Posts/Posts.xml stackoverflow.com/Posts.xml

--- a/lib/longtail/stackoverflow/README
+++ b/lib/longtail/stackoverflow/README
@@ -14,8 +14,9 @@ rm *.7z*
 rm -rf meta*
 find . | egrep -e 'Badges|PostHistory|Comments|PostLinks' | xargs rm -rf
 mkdir stackoverflow.com
-mv stackoverflow.com-Users/stackoverflow.com/Users.xml stackoverflow.com/Users.xml
-mv stackoverflow.com-Posts/stackoverflow.com/Posts.xml stackoverflow.com/Posts.xml
+mv stackoverflow.com-Users/Users.xml stackoverflow.com/Users.xml
+mv stackoverflow.com-Posts/Posts.xml stackoverflow.com/Posts.xml
+mv stackoverflow.com-PostLinks/PostLinks.xml stackoverflow.com/PostLinks.xml
 cd /usr/local/ddg/sources/stackoverflow
 ./posts.sh
 cd /tmp2/ddg/so


### PR DESCRIPTION
Add post-links information for StackOverflow data as well as vote counts for the parent post.
`<field name="meta">{"creation_date":"2016-02-28T18:04:22.273","accepted":"0","post_links":"40924,3294","parent_score","15"}</field>`

@zachthompson 