### PR TITLE
Remove Answer/Comment/FavoriteCounts

### DIFF
--- a/lib/longtail/stackoverflow/README
+++ b/lib/longtail/stackoverflow/README
@@ -12,4 +12,6 @@ rm meta*.7z stackoverflow.com-Badges.7z stackoverflow.com-Comments.7z stackoverf
 # zeroclickinfo-longtail is the path to your git clone
 zeroclickinfo-longtail/lib/longtail/stackoverflow/extract.sh
 zeroclickinfo-longtail/lib/longtail/stackoverflow/posts.pl -d .
+# Below here is unnecessary if your developing/testing
 bzip2 -v pre-process*.txt
+upload via s3cmd

--- a/lib/longtail/stackoverflow/README
+++ b/lib/longtail/stackoverflow/README
@@ -3,22 +3,13 @@ sudo apt-get -y install rtorrent
 apt-get -y install p7zip
 apt-get -y install moreutils
 
-cd /tmp2/ddg/
+# Mount where 7z files are extracted and processed should be very big, e.g. +75GB
+cd /directory
 # https://archive.org/details/stackexchange
 rtorrent https://archive.org/download/stackexchange/stackexchange_archive.torrent
-mv stackexchange so
-cd so
-cp -p /usr/local/ddg/sources/stackoverflow/extract.sh .
-./extract.sh
-rm *.7z*
-rm -rf meta*
-find . | egrep -e 'Badges|PostHistory|Comments' | xargs rm -rf
-mkdir stackoverflow.com
-mv stackoverflow.com-Users/Users.xml stackoverflow.com/Users.xml
-mv stackoverflow.com-Posts/Posts.xml stackoverflow.com/Posts.xml
-mv stackoverflow.com-PostLinks/PostLinks.xml stackoverflow.com/PostLinks.xml
-cd /usr/local/ddg/sources/stackoverflow
-./posts.sh
-cd /tmp2/ddg/so
-bzip2 -kzv pre-process*.txt
-s3cmd put *.bz2 s3://ddg-solr/sources/so/
+cd stackexchange
+rm meta*.7z stackoverflow.com-Badges.7z stackoverflow.com-Comments.7z stackoverflow.com-Comments.7z stackoverflow.com-Tags.7z stackoverflow.com-Votes.7z
+# zeroclickinfo-longtail is the path to your git clone
+zeroclickinfo-longtail/lib/longtail/stackoverflow/extract.sh
+zeroclickinfo-longtail/lib/longtail/stackoverflow/posts.pl -d .
+bzip2 -v pre-process*.txt

--- a/lib/longtail/stackoverflow/extract.sh
+++ b/lib/longtail/stackoverflow/extract.sh
@@ -3,6 +3,6 @@
 # ensure that the main stackoverflow archive is combined into 1 .7z file before running
 
 ls *.7z | while read LINE; do
-        file_name=$(echo $LINE | sed 's/.7z//g')
-        /usr/bin/7z e $LINE -o$file_name
+    file_name=$(echo $LINE | perl -pe 's/(?:-[^)]+)?.7z$//')
+    /usr/bin/7z e $LINE -o$file_name Users.xml Posts.xml PostLinks.xml
 done

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -27,10 +27,7 @@ my $accepted_answer_re = qr/^\s*
     Score="(\d+).*
     Body="([^\"]+)".*
     Title="([^\"]+)"\s+
-    Tags="([^\"]+)"\s+
-    AnswerCount="(\d+)"\s+
-    CommentCount="\d+"\s+
-    FavoriteCount="(\d+)"/x;
+    Tags="([^\"]+)"/x;
 
 my $no_accepted_answer_re = qr/^\s*
     <row\s+Id="(\d+)"\s+
@@ -39,10 +36,7 @@ my $no_accepted_answer_re = qr/^\s*
     Score="(\d+)".*
     Body="([^\"]+)".*
     Title="([^\"]+)"\s+
-    Tags="([^\"]+)"\s+
-    AnswerCount="(\d+)"\s+
-    CommentCount="\d+"\s+
-    FavoriteCount="(\d+)"/x;
+    Tags="([^\"]+)"/x;
 
 my $answer_re = qr/^\s*
     <row\s+Id="(\d+)"\s+
@@ -157,8 +151,6 @@ EOH
             #my $last_edit_date = $6;
             my $title = $6;
             my $tags = $7;
-            my $answer_count = $8;
-            my $favorite_count = $9;
     
             next if $score<0;
             $count_q2++;
@@ -195,8 +187,6 @@ EOH
             #        my $last_edit_date = $5;
             my $title = $5;
             my $tags = $6;
-            my $answer_count = $7;
-            my $favorite_count = $8;
     
     #        next if $score<3;
             next if $score<0;

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -116,7 +116,7 @@ while( my($name, $data) = each %$m){
     
     open(IN ,  "<:encoding(UTF-8)" , "$stack_dir/$data->{src_domain}/Posts.xml");
     open( OUT , ">:encoding(UTF-8)" , "$stack_dir/pre-process.$name.txt") ;
-    open( TMP , ">:encoding(UTF-8)" , "$stack_dir/tmp.txt") ;
+    #open( TMP , ">:encoding(UTF-8)" , "$stack_dir/tmp.txt") ;
     print OUT <<EOH;
 <?xml version="1.0" encoding="UTF-8"?>
 <add allowDups="true">
@@ -356,7 +356,7 @@ EOH
 </add>
 EOH
     close(OUT);
-    close(TMP);
+    #close(TMP);
     
     print qq($count\n);
     print qq(q: $count_q\n);

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -10,9 +10,6 @@ use DDG::Meta::Data;
 use HTML::Entities;
 use List::Util 'first';
 
-my %answer_ids;
-my %unanswered_ids;
-my %tmp;
 my $stack_dir;
 my @sources;
 
@@ -50,6 +47,10 @@ my $answer_re = qr/^\s*
 my $m = DDG::Meta::Data->filter_ias({is_stackexchange => 1});
 
 while( my($name, $data) = each %$m){
+    my %answer_ids;
+    my %unanswered_ids;
+    my %tmp;
+
     if(@sources){
         next unless first { $name eq $_ } @sources;
     }
@@ -365,11 +366,11 @@ EOH
     print qq(a3: $count_a3\n);
     
     # For debugging.
-    $count = 0;
-    for my $tmp (sort {$tmp{$b}<=>$tmp{$a}} keys %tmp) {
-        print $tmp{$tmp}, "\t", $tmp, "\n";
-        last if ++$count>50;
-    }
+    #$count = 0;
+    #for my $tmp (sort {$tmp{$b}<=>$tmp{$a}} keys %tmp) {
+    #    print $tmp{$tmp}, "\t", $tmp, "\n";
+    #    last if ++$count>50;
+    #}
 }
 
 # Page input is multi-line XML.


### PR DESCRIPTION
The last internal commit wasn't carried over here.

This has gone through a few more changes:

**extract.sh**

* Only extract wanted files for speed/space
* Have stackoverflow.com-* files extracted into stackoverflow.com automatically

**README**

* Remove unneeded 7z files before extracting to save time/space
* Remove commands that are now handled elsewhere
* Comments

**posts.pl**

* Output meta field as JSON
* Small refactoring