### PR TITLE
HTML entities and tags

### DIFF
--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -386,10 +386,11 @@ sub decode_encode_str {
     $str = '' if !(defined $str);
 
     # Decode encoded xml characters.
-    $str =~ s/\&lt\;/\</g;
-    $str =~ s/\&gt\;/\>/g;
-    $str =~ s/\&quot\;/\"/g;
-    $str =~ s/\&amp\;/\&/g;
+    $str =~ s/&lt;/</g;
+    $str =~ s/&gt;/>/g;
+    $str =~ s/&quot;/"/g;
+    # Only sub when not an &amp; for a literal entity, e.g. &amp;awint;
+    $str =~ s/\&amp;(?![^&\s;]+;)/&/g;
 
     # Encode special space characters.
     $str =~ s/\\/\\\\/g if !$no_db;

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -228,7 +228,12 @@ EOH
     
                 my $q = $answer_ids{$id} || $unanswered_ids{$parent_id};
                 my ($title, $q_tags) = @$q;
-    
+
+                my @tags;
+                for my $t (split /&[lg]t;/, $q_tags){
+                    push @tags, $t if $t;
+                }
+
                 # converts xml chars
                 $body = decode_encode_str($body,1);
                 $title = decode_encode_str($title,1);
@@ -325,7 +330,8 @@ EOH
                     creation_date => $date,
                     accepted => int($accepted || 0),
                     post_links => $post_links{$parent_id} || [],
-                    parent_score => int($parent_post_score{$parent_id} || 0)
+                    parent_score => int($parent_post_score{$parent_id} || 0),
+                    tags => \@tags
                 });
     
                 print OUT <<EOH;

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -81,7 +81,7 @@ for my $name (sort keys %$m){
             #    last;
         }
         close(IN)
-    };
+    }
 
     my %users = ();
     #my %karma = ();
@@ -385,15 +385,14 @@ EOH
 sub decode_encode_str {
     my ($str,$no_db) = @_;
 
-    # If no string assign it.
-    $str = '' if !(defined $str);
+    return '' unless $str;
 
     # Decode encoded xml characters.
     $str =~ s/\&lt\;/\</g;
     $str =~ s/\&gt\;/\>/g;
     $str =~ s/\&quot\;/\"/g;
     $str =~ s/\&#xD\;//g;
-    #$str =~ s/\&amp\;/\&/g;
+    #$str =~ s/\&amp\;(?![#\w]+;)/\&/g;
 
     # Encode special space characters.
     $str =~ s/\\/\\\\/g if !$no_db;

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -386,9 +386,9 @@ sub decode_encode_str {
     $str = '' if !(defined $str);
 
     # Decode encoded xml characters.
-    $str =~ s/&lt;/</g;
-    $str =~ s/&gt;/>/g;
-    $str =~ s/&quot;/"/g;
+    $str =~ s/\&lt;/</g;
+    $str =~ s/\&gt;/>/g;
+    $str =~ s/\&quot;/"/g;
     # Only sub when not an &amp; for a literal entity, e.g. &amp;awint;
     $str =~ s/\&amp;(?![^&\s;]+;)/&/g;
 

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -386,9 +386,9 @@ sub decode_encode_str {
     $str = '' if !(defined $str);
 
     # Decode encoded xml characters.
-    $str =~ s/\&lt;/</g;
-    $str =~ s/\&gt;/>/g;
-    $str =~ s/\&quot;/"/g;
+    $str =~ s/\&lt\;/</g;
+    $str =~ s/\&gt\;/>/g;
+    $str =~ s/\&quot\;/"/g;
     # Only sub when not an &amp; for a literal entity, e.g. &amp;awint;
     $str =~ s/\&amp;(?![^&\s;]+;)/&/g;
 

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -24,8 +24,8 @@ my $accepted_answer_re = qr/^\s*
     CreationDate="([^"]+)".*
     Score="(\d+).*
     Body="([^\"]+)".*
-    Title="([^\"]+)"/x;
-    #Tags="([^\"]+)"/x;
+    Title="([^\"]+)"\s+
+    Tags="([^\"]+)"/x;
 
 my $no_accepted_answer_re = qr/^\s*
     <row\s+Id="(\d+)"\s+
@@ -33,8 +33,8 @@ my $no_accepted_answer_re = qr/^\s*
     CreationDate="([^"]+)".*
     Score="(\d+)".*
     Body="([^\"]+)".*
-    Title="([^\"]+)"/x;
-    #Tags="([^\"]+)"/x;
+    Title="([^\"]+)"\s+
+    Tags="([^\"]+)"/x;
 
 my $answer_re = qr/^\s*
     <row\s+Id="(\d+)"\s+
@@ -153,7 +153,7 @@ EOH
             my $body = $5;
             #my $last_edit_date = $6;
             my $title = $6;
-            #my $tags = $7;
+            my $tags = $7;
     
             next if $score<0;
             $count_q2++;
@@ -172,8 +172,8 @@ EOH
             #print qq($body\n) if $body;
     
     
-            $answer_ids{$accepted_answer} = $title;
-            $unanswered_ids{$id} = $title;
+            $answer_ids{$accepted_answer} = [$title, $tags];
+            $unanswered_ids{$id} = [$title, $tags];
     
         # Post without accepted answer.
         }
@@ -189,6 +189,7 @@ EOH
             my $body = $4;
             #        my $last_edit_date = $5;
             my $title = $5;
+            my $tags = $6;
     
     #        next if $score<3;
             next if $score<0;
@@ -198,7 +199,7 @@ EOH
             # For debugging.
             #print qq(test\n);
     
-            $unanswered_ids{$id} = $title;
+            $unanswered_ids{$id} = [$title, $tags];
     
         # Answers.
         }
@@ -225,7 +226,8 @@ EOH
                 # For debugging.
                 #    print qq(test\n) if exists $unanswered_ids{$parent_id};
     
-                my $title = $answer_ids{$id} || $unanswered_ids{$parent_id};
+                my $q = $answer_ids{$id} || $unanswered_ids{$parent_id};
+                my ($title, $q_tags) = @$q;
     
                 # converts xml chars
                 $body = decode_encode_str($body,1);

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -386,9 +386,9 @@ sub decode_encode_str {
     $str = '' if !(defined $str);
 
     # Decode encoded xml characters.
-    $str =~ s/\&lt\;/</g;
-    $str =~ s/\&gt\;/>/g;
-    $str =~ s/\&quot\;/"/g;
+    $str =~ s/\&lt\;/\</g;
+    $str =~ s/\&gt\;/\>/g;
+    $str =~ s/\&quot\;/\"/g;
     # Only sub when not an &amp; for a literal entity, e.g. &amp;awint;
     $str =~ s/\&amp;(?![^&\s;]+;)/&/g;
 

--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -24,8 +24,8 @@ my $accepted_answer_re = qr/^\s*
     CreationDate="([^"]+)".*
     Score="(\d+).*
     Body="([^\"]+)".*
-    Title="([^\"]+)"\s+
-    Tags="([^\"]+)"/x;
+    Title="([^\"]+)"/x;
+    #Tags="([^\"]+)"/x;
 
 my $no_accepted_answer_re = qr/^\s*
     <row\s+Id="(\d+)"\s+
@@ -33,8 +33,8 @@ my $no_accepted_answer_re = qr/^\s*
     CreationDate="([^"]+)".*
     Score="(\d+)".*
     Body="([^\"]+)".*
-    Title="([^\"]+)"\s+
-    Tags="([^\"]+)"/x;
+    Title="([^\"]+)"/x;
+    #Tags="([^\"]+)"/x;
 
 my $answer_re = qr/^\s*
     <row\s+Id="(\d+)"\s+
@@ -153,7 +153,7 @@ EOH
             my $body = $5;
             #my $last_edit_date = $6;
             my $title = $6;
-            my $tags = $7;
+            #my $tags = $7;
     
             next if $score<0;
             $count_q2++;
@@ -172,8 +172,8 @@ EOH
             #print qq($body\n) if $body;
     
     
-            $answer_ids{$accepted_answer} = qq($title~|~$tags);
-            $unanswered_ids{$id} = qq($title~|~$tags);
+            $answer_ids{$accepted_answer} = $title;
+            $unanswered_ids{$id} = $title;
     
         # Post without accepted answer.
         }
@@ -189,7 +189,6 @@ EOH
             my $body = $4;
             #        my $last_edit_date = $5;
             my $title = $5;
-            my $tags = $6;
     
     #        next if $score<3;
             next if $score<0;
@@ -199,7 +198,7 @@ EOH
             # For debugging.
             #print qq(test\n);
     
-            $unanswered_ids{$id} = qq($title~|~$tags);
+            $unanswered_ids{$id} = $title;
     
         # Answers.
         }
@@ -226,11 +225,7 @@ EOH
                 # For debugging.
                 #    print qq(test\n) if exists $unanswered_ids{$parent_id};
     
-                my $q = $answer_ids{$id} || $unanswered_ids{$parent_id};
-                my @q = split(/\~\|\~/o,$q);
-   
-                my $title = $q[0];
-                my $q_tags = $q[1];
+                my $title = $answer_ids{$id} || $unanswered_ids{$parent_id};
     
                 # converts xml chars
                 $body = decode_encode_str($body,1);
@@ -389,8 +384,8 @@ sub decode_encode_str {
     $str =~ s/\&lt\;/\</g;
     $str =~ s/\&gt\;/\>/g;
     $str =~ s/\&quot\;/\"/g;
-    # Only sub when not an &amp; for a literal entity, e.g. &amp;awint;
-    $str =~ s/\&amp;(?![^&\s;]+;)/&/g;
+    $str =~ s/\&#xD\;//g;
+    #$str =~ s/\&amp\;/\&/g;
 
     # Encode special space characters.
     $str =~ s/\\/\\\\/g if !$no_db;


### PR DESCRIPTION
We're doing it globally which potentially turns something like
```
&amp;#ent;
```
into
```
&#ent;
```
causing it to display the character itself, rather than the entity.

The script also lets through carriage returns which turn into `^M`s.

Add `tags` to the `meta` field.

See: https://github.com/duckduckgo/zeroclickinfo-longtail/issues/44 and https://github.com/duckduckgo/zeroclickinfo-longtail/issues/37