### PR TITLE
Mirror Stack Exchange files

### DIFF
--- a/lib/longtail/stackoverflow/README.md
+++ b/lib/longtail/stackoverflow/README.md
@@ -5,7 +5,6 @@
 
 2. Install Pre-reqs
  ```
- sudo apt-get -y install rtorrent
  apt-get -y install p7zip
  apt-get -y install moreutils
  ```
@@ -16,11 +15,9 @@
  mkdir download && cd download
  ```
 
-4. Download archive torrent from https://archive.org/details/stackexchange
+4. Mirror 7z files from https://archive.org/details/stackexchange
  ```
- rtorrent https://archive.org/download/stackexchange/stackexchange_archive.torrent
- cd stackexchange
- rm meta*.7z stackoverflow.com-Badges.7z stackoverflow.com-Comments.7z stackoverflow.com-Comments.7z stackoverflow.com-Tags.7z stackoverflow.com-Votes.7z
+ mirror_stackexchange.pl -d download -v
  ```
 
 5. Generate output file

--- a/lib/longtail/stackoverflow/mirror_stackexchange.pl
+++ b/lib/longtail/stackoverflow/mirror_stackexchange.pl
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+
+use LWP::UserAgent;
+use DDG::Meta::Data;
+
+my $archive_org = 'http://archive.org/download/stackexchange/';
+
+my ($se_dir, $verbose);
+parse_argv();
+
+my $ua = LWP::UserAgent->new;
+my %m = %{DDG::Meta::Data->filter_ias({is_stackexchange => 1})};
+
+for my $id (sort keys %m){
+
+    my $ia = $m{$id};
+    my $src_dom = $ia->{src_domain};
+
+    my @zips;
+    if($src_dom eq 'stackoverflow.com'){
+        for my $t (qw(Users Posts PostLinks)){
+            push @zips, "$src_dom-$t.7z";
+        }
+    }
+    else{
+        push @zips, "$src_dom.7z";
+    }
+
+    for my $z (@zips){
+        my $res = $ua->mirror("$archive_org/$z", "$se_dir/$z");
+        if($res->is_success){
+            warn "Downloaded new version of $z\n";
+        }
+        elsif($res->code == 304){
+            $verbose && warn "$z unchanged\n";
+        }
+        else{
+            warn "Failed to check $z: ", $res->status_line;
+        }
+    }
+}
+
+sub parse_argv {
+    my $usage = <<ENDOFUSAGE;
+
+     *********************************************************************
+       USAGE: mirror_stackexchange.pl -d dir [-v]
+
+       OVERVIEW
+
+       Mirrors the 7z files from https://archive.org/details/stackexchange
+       to a local directory. Downloads the files based on the is_stackexchange
+       flag in metadata.
+
+       OPTIONS
+       
+       -d  Directory in which 7z files will be stored.
+       -v: (optional) Verbose, will output additional info.
+
+
+    ***********************************************************************
+
+ENDOFUSAGE
+
+    my $min_args = 2;
+
+    die $usage unless $min_args <= @ARGV;
+
+    for(my $i = 0;$i < @ARGV;$i++) {
+        if($ARGV[$i] =~ /^-d$/i ){ $se_dir = $ARGV[++$i] }
+        elsif($ARGV[$i] =~ /^-v$/i){ ++$verbose }
+    }
+}


### PR DESCRIPTION
Rather than using the torrent, only download the 7z files we need and mirror them.  Will address https://github.com/duckduckgo/zeroclickinfo-longtail/issues/80