### PR TITLE
REPO: Removed Prog Mission info from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@
 
 We're a community dedicated to improving search results with open source, "Instant Answers." Instant Answers use the Web's best APIs and data to solve searches in few or zero clicks. Together and openly, we can create the best search engine for every type of search.
 
-**The DuckDuckHack community and DuckDuckGo staff are working together on a mission to create the best search engine for programmers. To fully focus there, we are only accepting Pull Requests and Issues related to the [Programming Mission](https://forum.duckduckhack.com/t/duckduckhack-programming-mission-overview/53).** By working directly with contributors to this mission, we can more quickly provide search data and open source tools which give contributors and their Instant Answers more impact than ever before!
-
-[**Join the Programming Mission!**](https://forum.duckduckhack.com/t/duckduckhack-programming-mission-overview/53)  
-*Your help and expertise can have a huge impact on improving the search experience for developers and DuckDuckGo users around the world!* 
-
 More Resources:   
 *[Full documentation](http://docs.duckduckhack.com)*  
 *[Instant Answers in Production](https://duck.co/ia)*  


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Removes the Programming Mission description on this ZCI repo's README. See related PRs:

Goodies: https://github.com/duckduckgo/zeroclickinfo-goodies/pull/3997
Spice: https://github.com/duckduckgo/zeroclickinfo-spice/pull/3186
Fathead: https://github.com/duckduckgo/zeroclickinfo-fathead/pull/861
Longtail: https://github.com/duckduckgo/zeroclickinfo-longtail/pull/105


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: n/a
<!-- FILL THIS IN:                           ^^^^ -->
