### PR TITLE
Stack: Replace https for http for stack's imgur for image proxy

### DIFF
--- a/lib/longtail/stackoverflow/posts.pl
+++ b/lib/longtail/stackoverflow/posts.pl
@@ -250,6 +250,8 @@ sub process_answers{
         #  $body =~ s/(<pre><code>)/$1/isg;
         $body =~ s/(<\/p>)/ $1/isg;
         # $body =~ s/(<\/code><\/pre>)/$1/isg;
+        # temporary fix for image proxy
+        $body =~ s{<img\s+src="https://i\.stack\.imgur\.com}{<img src="http://i.stack.imgur.com}gi;
 
         my ($uid, $uname);
         if ($user_id){


### PR DESCRIPTION
Sub http for https for Stack's imgur links.  Hopefully temporary.  Requests still go through https on our proxy.

One small concern I thought of was if a post has stack image code as an example.

